### PR TITLE
Add slint lang tree-sitter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -148,3 +148,6 @@
 [submodule "grammars/tree-sitter-zig"]
 	path = grammars/tree-sitter-zig
 	url = https://github.com/maxxnino/tree-sitter-zig.git
+[submodule "grammars/tree-sitter-slint"]
+	path = grammars/tree-sitter-slint
+	url = https://github.com/slint-ui/tree-sitter-slint.git

--- a/config.toml
+++ b/config.toml
@@ -135,6 +135,9 @@ path = "./grammars/tree-sitter-scheme"
 [grammars.tree-sitter-scss]
 path = "./grammars/tree-sitter-scss"
 
+[grammars.tree-sitter-slint]
+path = "./grammars/tree-sitter-slint"
+
 [grammars.tree-sitter-sql]
 path = "./grammars/tree-sitter-sql"
 


### PR DESCRIPTION
I don't know if there is anything else I need to do here. I have built and added the resulting lib to the grammars dir but the lang does not show up - I assume I need to also add the base support for lapce.